### PR TITLE
Update server.js to support URL encoded components

### DIFF
--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ Return the server's request handler function
 */
 function requestHandler(server) {
   return function handler(req, res) {
-    var uri = req.path = url.parse(req.url).pathname;
+    var uri = req.path = decodeURIComponent(url.parse(req.url).pathname);
     var filename = path.join(server.rootPath, uri);
     var timestamp = process.hrtime();
 


### PR DESCRIPTION
This allows for the server to receive a request with a path like `/Foo%20Bar.html`. As the path is now correctly decoded to `/Foo Bar.html` instead of `/Foo%20Bar.html`.